### PR TITLE
Change log level to `warn`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+---
+language: python
+python: "2.7"
+
+before_install:
+  # Make sure everything's up to date.
+  - sudo apt-get update -qq
+
+install:
+  # Install Ansible.
+  - pip install ansible
+
+  # Add ansible.cfg to pick up roles path.
+  - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
+
+script:
+  # Check the role/playbook's syntax.
+  - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
+
+
+webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/odoo/.travis.yml
+++ b/odoo/.travis.yml
@@ -1,0 +1,18 @@
+---
+language: python
+python: "2.7"
+
+before_install:
+  # Make sure everything's up to date.
+  - sudo apt-get update -qq
+
+install:
+  # Install Ansible.
+  - pip install ansible==2.4.3.0
+
+  # Add ansible.cfg to pick up roles path.
+  - "printf '[defaults]\nroles_path = ../' > ansible.cfg"
+
+script:
+
+webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/odoo/defaults/main.yml
+++ b/odoo/defaults/main.yml
@@ -16,7 +16,7 @@ odoo_config_path: /etc/odoo
 odoo_modules_path: /opt/odoo/modules
 
 odoo_log_path: /var/log/odoo
-odoo_log_level: warning
+odoo_log_level: warn
 
 # This not a DB user password, but a password for Odoo to allow Odoo deal with DB.
 odoo_db_admin_password: iT0ohDuoth6ONgahDeepaich0aeka5ul


### PR DESCRIPTION
Changed log level from `warning` to `warn` accepted by Odoo:

```
optparse.OptionValueError: option log_level: invalid choice: 'warning' (choose from 'info', 'debug_rpc', 'warn', 'test', 'critical', 'debug_sql', 'error', 'debug', 'debug_rpc_answer', 'notset')
```

https://www.odoo.com/documentation/11.0/reference/cmdline.html#logging